### PR TITLE
Setup/Remove serviço do chrome mantendo o navegador no serviço do front

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby
+
+WORKDIR /app
+
+RUN apt-get update -y && apt-get install -y chromium-driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,22 +38,11 @@ services:
   redis:
     image: redis
 
-  chrome:
-    image: browserless/chrome:1.31-chrome-stable
-    ports:
-      - '3333:3333'
-    volumes:
-      - .:/app:cached
-    environment:
-      PORT: 3333
-
   front:
-    image: ruby:latest
+    build: .
     working_dir: /app
     volumes:
       - ./front:/app
-    depends_on:
-      - chrome 
     ports:
       - "2000:2000"
     command: bash -c 'gem install bundler && bundle install && ruby server.rb'

--- a/front/spec/spec_helper.rb
+++ b/front/spec/spec_helper.rb
@@ -9,8 +9,7 @@ Capybara.register_driver(:cuprite) do |app|
     app,
     window_size: [1200, 800],
     browser_options: { 'no-sandbox': nil },
-    inspector: true,
-    url:  'http://chrome:3333'
+    inspector: true
   )
 end
 


### PR DESCRIPTION
Essa PR mantém o navegador para testes de sistema junto ao serviço do front dispensando serviço extra do navegador.