### PR TITLE
Adiciona tratamento dos pontos citados no feedback

### DIFF
--- a/back/controllers/import_controller.rb
+++ b/back/controllers/import_controller.rb
@@ -9,6 +9,10 @@ post '/import' do
 
   rows = CSV.read(params[:file][:tempfile], col_sep: ';')
 
+  invalid_csv = CSVImporter.validate_csv(rows)
+
+  return { error: invalid_csv.join(', ') }.to_json if invalid_csv.any?
+
   CSVImporterJob.perform_async(rows)
 
   { done: 'Your document has been enqueued to import' }.to_json

--- a/back/helpers/csv_importer.rb
+++ b/back/helpers/csv_importer.rb
@@ -4,11 +4,11 @@ require_relative '../services/database'
 Dir[File.join(__dir__, '../models', '*.rb')].each { |file| require file }
 
 class CSVImporter
-  def self.import(csv_rows = nil)
+  def self.import(csv_data = nil)
     connection = DatabaseConfig.connect
 
-    rows = csv_rows if csv_rows
-    rows = CSV.read('./data/data.csv', col_sep: ';') if csv_rows.nil?
+    rows = csv_data if csv_data
+    rows = CSV.read('./data/data.csv', col_sep: ';') if csv_data.nil?
 
     columns = rows.shift
     
@@ -61,5 +61,40 @@ class CSVImporter
       end
     end
     connection.close
+  end
+
+  def self.validate_csv(csv_rows)
+    return ['CSV cannot be blank'] if csv_rows.empty?
+
+    errors = []
+
+    expected_columns = [
+      "cpf",
+      "nome paciente",
+      "email paciente",
+      "data nascimento paciente",
+      "endereço/rua paciente",
+      "cidade paciente",
+      "estado patiente",
+      "crm médico",
+      "crm médico estado",
+      "nome médico",
+      "email médico",
+      "token resultado exame",
+      "data exame",
+      "tipo exame",
+      "limites tipo exame",
+      "resultado tipo exame"
+    ]
+
+    csv_rows.map.with_index do |row, idx|
+      error_msg_column = 'CSV does not have all or any columns at first line'
+      error_msg_value = "CSV does not have all or any values at line #{idx + 1}"
+
+      errors << error_msg_column if idx == 0 && row != expected_columns
+      errors << error_msg_value if (idx == 0 && csv_rows.size == 1) || (idx != 0 && row.size != 16)
+    end
+
+    errors
   end
 end

--- a/back/services/test_service.rb
+++ b/back/services/test_service.rb
@@ -99,9 +99,12 @@ class TestService
          e.id, p.id, d.id
        ORDER BY
          e.id;
-    ").entries.first
+    ")
     
     conn.close
+
+    return { error: 'Invalid token' }.to_json if result.nil?
+    result = result.entries.first
     
     result['patient'] = JSON.parse result['patient']
     result['doctor'] = JSON.parse result['doctor']

--- a/back/spec/helpers/csv_importer_spec.rb
+++ b/back/spec/helpers/csv_importer_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 require_relative '../../helpers/csv_importer'
 
 RSpec.describe CSVImporter, type: :helper do
-  describe '#import' do
+  context '#import' do
     it 'should populate the database with tests' do
       fake_csv = [
-        ['cpf', 'nome paciente', 'email paciente', 'data nascimento paciente', 'endereço/rua paciente', 'cidade paciente', 'estado paciente', 'crm médico', 'crm médico estado', 'nome médico', 'email médico', 'token resultado exame', 'data exame', 'tipo exame', 'limites tipo exame', 'resultado tipo exame'],
+        ['cpf', 'nome paciente', 'email paciente', 'data nascimento paciente', 'endereço/rua paciente', 'cidade paciente', 'estado patiente', 'crm médico', 'crm médico estado', 'nome médico', 'email médico', 'token resultado exame', 'data exame', 'tipo exame', 'limites tipo exame', 'resultado tipo exame'],
         ['048.973.170-88', 'Emilly Batista Neto', 'gerald.crona@ebert-quigley.com', '2001-03-11', '165 Rua Rafaela', 'Ituverava', 'Alagoas', 'B000BJ20J4', 'PI', 'José Aldo', 'denna@wisozk.biz', 'IQCZ17', '2021-08-05', 'hemácias', '45-52', '97'],
         ['066.126.400-90', 'Matheus Barroso', 'maricela@streich.com', '1972-03-09', '9378 Rua Stella Braga', 'Senador Elói de Souza', 'Pernambuco', 'B000BJ20J4', 'PI', 'José Aldo', 'kendra@nolan-sawayn.co', 'T9O6AI', '2021-11-21', 'hdl', '19-75', '3'],
         ['089.034.562-70', 'Patricia Gentil', 'herta_wehner@krajcik.name', '1998-02-25', '5334 Rodovia Thiago Bittencourt', 'Jequitibá', 'Paraná', 'B0002W2RBG', 'CE', 'Dra. Isabelly Rêgo', 'diann_klein@schinner.org', 'TJUXC2', '2021-10-05', 'plaquetas','11-93', '26'],
@@ -23,6 +23,28 @@ RSpec.describe CSVImporter, type: :helper do
       expect(doctors.count).to eq 2
       expect(exams.count).to eq 3
       expect(tests.count).to eq 4
+    end
+  end
+
+  context '#validate_csv' do
+    it 'validate blank CSV file' do
+      fake_csv = []
+
+      allow(CSV).to receive(:read).and_return(fake_csv)
+      result = CSVImporter.validate_csv(fake_csv)
+
+      expect(result).to include 'CSV cannot be blank'
+    end
+
+    it 'validate columns and values of CSV file' do
+      fake_csv = CSV.read(File.expand_path('../support/invalid_data.csv', __dir__), col_sep: ';')
+
+      allow(CSV).to receive(:read).and_return(fake_csv)
+      result = CSVImporter.validate_csv(fake_csv)
+
+      expect(result).to include 'CSV does not have all or any columns at first line'
+      expect(result).to include 'CSV does not have all or any values at line 2'
+      expect(result).to include 'CSV does not have all or any values at line 3'
     end
   end
 end

--- a/back/spec/request/csv_importer_job_spec.rb
+++ b/back/spec/request/csv_importer_job_spec.rb
@@ -4,20 +4,27 @@ require_relative '../../controllers/import_controller.rb'
 describe 'POST /import' do
   it 'must enqueue imported csv data' do
     file_path = File.expand_path('../support/small_data.csv', __dir__) 
-
     fake_data = CSV.read(file_path, col_sep: ';')
-
     fake_csv = 'spec/support/small_data.csv'
     spy_csv_importer_job = spy('CSVImporterJob')
     stub_const('CSVImporterJob', spy_csv_importer_job)
-
+    
     allow(CSV).to receive(:read).and_return(fake_data)
-
     post '/import', file: Rack::Test::UploadedFile.new(fake_csv, 'text/csv')
 
-    expect(CSVImporterJob).to have_received(:perform_async).with(fake_data)
+    expect(spy_csv_importer_job).to have_received(:perform_async).with(fake_data)
     expect(last_response.content_type).to include 'application/json'
     json_response = JSON.parse(last_response.body, symbolize_names: true)
     expect(json_response[:done]).not_to be_nil
+  end
+
+  it 'fails' do
+    fake_data = []
+    fake_csv = 'spec/support/small_data.csv'
+
+    allow(CSV).to receive(:read).and_return(fake_data)
+    post '/import', file: Rack::Test::UploadedFile.new(fake_csv, 'text/csv')
+    
+    expect(JSON.parse(last_response.body)).to eq({"error" => "CSV cannot be blank"})
   end
 end

--- a/back/spec/services/test_service_spec.rb
+++ b/back/spec/services/test_service_spec.rb
@@ -156,5 +156,15 @@ RSpec.describe TestService, type: :service do
         }
       )
     end
+
+    it 'error when token is invalid' do
+      db_result = nil
+    
+      db_connection = double('PG::Connection', exec: db_result, close: nil)
+      allow(DatabaseConfig).to receive(:connect).and_return(db_connection)
+    
+      parsed_tests = JSON.parse(TestService.parse_tests_by_token('Invalid 123'))
+      expect(parsed_tests).to eq({'error'=>'Invalid token'})
+    end    
   end
 end

--- a/back/spec/services/test_service_spec.rb
+++ b/back/spec/services/test_service_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../services/test_service'
 
 RSpec.describe TestService, type: :service do
   context '.parse_tests' do
-    it 'parses test results correctly' do
+    it 'must return a JSON with all tests' do
       db_result = [
         {
           'result_token' => 'IQCZ17',
@@ -82,7 +82,7 @@ RSpec.describe TestService, type: :service do
   end
 
   context '.parse_tests_by_token' do
-    it 'must return a JSON with full tests per token' do
+    it 'must return a JSON with full test per token' do
       db_result = [
         {
           'result_token' => 'IQCZ17',

--- a/back/spec/support/invalid_data.csv
+++ b/back/spec/support/invalid_data.csv
@@ -1,0 +1,3 @@
+endereço/rua paciente;cidade paciente;estado patiente;crm médico;crm médico estado;nome médico;email médico;token resultado exame;data exame;tipo exame;limites tipo exame;resultado tipo exame
+gerald.crona@ebert-quigley.com;2001-03-11;165 Rua Rafaela;Ituverava;Alagoas;B000BJ20J4;PI;Maria Luiza Pires;denna@wisozk.biz;IQCZ17;2021-08-05;hemácias;45-52;97
+527 Rodovia Júlio;Lagoa da Canoa;Paraíba;B0002IQM66;SC;Maria Helena Ramalho;rayford@kemmer-kunze.info;0W9I67;2021-07-09;hemácias;45-52;28

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
     volumes:
       - ./back:/app
+      - bundle_data_back:/usr/local/bundle
     ports:
       - "3000:3000"
     depends_on:
@@ -43,7 +44,12 @@ services:
     working_dir: /app
     volumes:
       - ./front:/app
+      - bundle_data_front:/usr/local/bundle
     ports:
       - "2000:2000"
     command: bash -c 'gem install bundler && bundle install && ruby server.rb'
     container_name: relabs-front
+
+volumes:
+  bundle_data_back:
+  bundle_data_front:

--- a/front/Gemfile
+++ b/front/Gemfile
@@ -9,6 +9,7 @@ gem 'faraday-multipart'
 group :test do
   gem 'capybara'
   gem 'cuprite'
+  gem 'debug'
   gem 'rack-test'
   gem 'rspec'
 end

--- a/front/Gemfile.lock
+++ b/front/Gemfile.lock
@@ -17,6 +17,9 @@ GEM
     cuprite (0.15)
       capybara (~> 3.0)
       ferrum (~> 0.14.0)
+    debug (1.9.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.5.1)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
@@ -29,6 +32,10 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (>= 0.6, < 0.8)
+    io-console (0.7.2)
+    irb (1.12.0)
+      rdoc
+      reline (>= 0.4.2)
     matrix (0.4.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
@@ -43,6 +50,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
+    psych (5.1.2)
+      stringio
     public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
@@ -58,7 +67,11 @@ GEM
     rackup (2.1.0)
       rack (>= 3)
       webrick (~> 1.8)
+    rdoc (6.6.3.1)
+      psych (>= 4.0.0)
     regexp_parser (2.9.0)
+    reline (0.4.3)
+      io-console (~> 0.5)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -79,6 +92,7 @@ GEM
       rack-protection (= 4.0.0)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
+    stringio (3.1.0)
     tilt (2.3.0)
     uri (0.13.0)
     webrick (1.8.1)
@@ -95,6 +109,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   cuprite
+  debug
   faraday
   faraday-multipart
   puma

--- a/front/public/css/style.css
+++ b/front/public/css/style.css
@@ -36,14 +36,6 @@ input[type="text"], input[type="file"], button, nav a {
   gap: 2px
 }
 
-.back-list {
-  display: block;
-}
-
-.back-list-none {
-  display: none;
-}
-
 input[type="file"] {
   display: none;
 }
@@ -84,11 +76,11 @@ button:hover, nav a:hover {
   display: flex; 
   flex-direction: column; 
   align-items: center;
+  margin-top: 1rem;
 }
 
 table {
   width: 85%; 
-  margin-top: 1rem;
 }
 
 table thead tr th {

--- a/front/public/css/style.css
+++ b/front/public/css/style.css
@@ -96,6 +96,10 @@ table thead tr th {
   padding: 10px;
 }
 
+table tbody tr:not(.test-details) {
+  cursor: pointer;
+}
+
 table tbody tr td {
   padding: 8px;
 }
@@ -108,6 +112,6 @@ table tbody tr:nth-child(even) {
   background-color: #ddd; 
 }
 
-.table-model {
+.table-list-model, .table-details-model {
   display: none;
 }

--- a/front/public/css/style.css
+++ b/front/public/css/style.css
@@ -100,6 +100,10 @@ table tbody tr:not(.test-details) {
   cursor: pointer;
 }
 
+table tbody tr:not(.test-details):hover {
+  opacity: 0.8;
+}
+
 table tbody tr td {
   padding: 8px;
 }

--- a/front/public/css/style.css
+++ b/front/public/css/style.css
@@ -111,3 +111,11 @@ table tbody tr:nth-child(even) {
 .table-list-model, .table-details-model {
   display: none;
 }
+
+.active-page {
+  background-color: #618cfa;
+}
+
+.pagination-controls {
+  margin-top: 1rem;
+}

--- a/front/public/css/style.css
+++ b/front/public/css/style.css
@@ -30,9 +30,18 @@ input[type="text"], input[type="file"], button, nav a {
   border-radius: 5px;
   font-size: 16px;
 }
+
 .search-token {
   display: flex;
   gap: 2px
+}
+
+.back-list {
+  display: block;
+}
+
+.back-list-none {
+  display: none;
 }
 
 input[type="file"] {
@@ -72,7 +81,6 @@ button:hover, nav a:hover {
 }
 
 #tables-list {
-  text-align: center; 
   display: flex; 
   flex-direction: column; 
   align-items: center;
@@ -83,19 +91,23 @@ table {
   margin-top: 1rem;
 }
 
-table > thead > tr:first-child th {
+table thead tr th {
   text-align: left;
   padding: 10px;
 }
 
+table tbody tr td {
+  padding: 8px;
+}
+
+table tbody tr:nth-child(odd) {
+  background-color: #f2f2f2; 
+}
+
+table tbody tr:nth-child(even) {
+  background-color: #ddd; 
+}
+
 .table-model {
-  display: none;
-}
-
-.back-list {
-  display: block;
-}
-
-.back-list-none {
   display: none;
 }

--- a/front/public/js/buildTable.js
+++ b/front/public/js/buildTable.js
@@ -1,33 +1,17 @@
-const buildTable = async (obj, idx) => {
+const buildTable = async (tests) => {
     const table = document.querySelector('.table-model').cloneNode(true);
-    table.classList.remove('table-model');
-    table.classList.add(`table-${idx}`)
-
-    table.querySelector('#doctor').innerHTML = `
-        Doctor: ${obj.doctor.name} <br>
-        CRM: ${obj.doctor.crm}-${obj.doctor.crm_state}
-    `;
-    table.querySelector('#patient').innerHTML = `
-        Patient: ${obj.patient.name} <br>
-        CPF: ${obj.patient.cpf} <br>
-        Date of birth: ${obj.patient.birthdate.replace(/-/g, "/")} <br>
-        Address: ${obj.patient.address} - ${obj.patient.city} / ${obj.patient.state}
-    `;
-    table.querySelector('#exam').innerHTML = `
-        Token: ${obj.result_token} <br>
-        Result Date: ${obj.result_date.replace(/-/g, "/")} <br>
-    `;
-
     const tbody = table.querySelector('tbody');
+    table.classList.remove('table-model');
 
-    tbody.innerHTML = obj.tests.map(test => {
-        const [min, max] = test.limits.split('-');
-        
+    tbody.innerHTML = tests.map((test, idx) => {
         return `
-            <tr>
-                <td>${test.type}</td>
-                <td>${min} to ${max}</td>
-                <td>${test.results}</td>
+            <tr class="row-${idx}">
+                <td>${test.result_token}</td>
+                <td>${test.result_date.replace(/-/g, "/")}</td> 
+                <td>${test.patient.name}</td>
+                <td>${test.patient.cpf}</td>
+                <td>${test.doctor.name}</td>
+                <td>${test.doctor.crm}/${test.doctor.crm_state}</td>
             </tr>
         `;
     }).join('');

--- a/front/public/js/buildTestDetails.js
+++ b/front/public/js/buildTestDetails.js
@@ -1,0 +1,50 @@
+import fetchData from "./fetchData.js";
+
+const buildTestDetails = async (token) => {
+    let test = null
+    try {
+        test = await fetchData(`/fetch/${token}`);
+        test = test instanceof Array ? test[0] : test;
+    } catch (error) {
+        console.error(`error when building test details ${error}`)
+        return;
+    }
+    
+    document.getElementById('tables-list').innerHTML = '';
+    const table = document.querySelector('.table-details-model').cloneNode(true);
+    table.classList.remove('table-details-model');
+
+    table.querySelector('#doctor').innerHTML = `
+        Doctor: ${test.doctor.name} <br>
+        CRM: ${test.doctor.crm}/${test.doctor.crm_state}
+    `;
+    table.querySelector('#patient').innerHTML = `
+        Patient: ${test.patient.name} <br>
+        CPF: ${test.patient.cpf} <br>
+        Date of birth: ${test.patient.birthdate.replace(/-/g, "/")} <br>
+        Address: ${test.patient.address} - ${test.patient.city} / ${test.patient.state}
+    `;
+    table.querySelector('#exam').innerHTML = `
+        Token: ${test.result_token} <br>
+        Result Date: ${test.result_date.replace(/-/g, "/")} <br>
+    `;
+
+    const tbody = table.querySelector('tbody');
+
+    tbody.innerHTML = test.tests.map(test => {
+        const [min, max] = test.limits.split('-');
+        
+        return `
+            <tr class="test-details">
+                <td>${test.type}</td>
+                <td>${min} to ${max}</td>
+                <td>${test.results}</td>
+            </tr>
+        `;
+    }).join('');
+
+    document.querySelector('#tables-list').appendChild(table)
+
+};
+
+export default buildTestDetails;

--- a/front/public/js/buildTestDetails.js
+++ b/front/public/js/buildTestDetails.js
@@ -1,10 +1,15 @@
 import fetchData from "./fetchData.js";
+import listeners from './listeners.js';
 
 const buildTestDetails = async (token) => {
     let test = null
     try {
         test = await fetchData(`/fetch/${token}`);
         test = test instanceof Array ? test[0] : test;
+        if (test.error) {
+            alert(test.error);
+            return;
+        }
     } catch (error) {
         console.error(`error when building test details ${error}`)
         return;
@@ -43,8 +48,17 @@ const buildTestDetails = async (token) => {
         `;
     }).join('');
 
-    document.querySelector('#tables-list').appendChild(table)
+    const list = document.getElementById('tables-list')
+    const divBackButton = document.createElement('div');
+    const backButton = document.createElement('button');
+    
+    backButton.innerText = 'Back to list';
 
+    list.appendChild(table)
+    divBackButton.appendChild(backButton)
+    list.insertBefore(divBackButton, list.firstChild);
+    
+    listeners.backToList(backButton);
 };
 
 export default buildTestDetails;

--- a/front/public/js/buildTestList.js
+++ b/front/public/js/buildTestList.js
@@ -1,10 +1,17 @@
-const buildTestList = async (tests) => {
+const testMode = document.querySelector('meta[name="test-mode"]').getAttribute('content') === 'true';
+const ITEMS_PER_PAGE = testMode ? 1 : 5;
+
+const buildTestList = async (tests, currentPage) => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+    const testsForCurrentPage = tests.slice(startIndex, endIndex);
+
     const table = document.querySelector('.table-list-model').cloneNode(true);
     const tbody = table.querySelector('tbody');
     table.classList.remove('table-list-model');
     document.getElementById('tables-list').innerHTML = '';
 
-    tbody.innerHTML = tests.map((test, idx) => {
+    tbody.innerHTML = testsForCurrentPage.map((test, idx) => {
         return `
             <tr class="row-${idx}" data-token="${test.result_token}">
                 <td>${test.result_token}</td>
@@ -18,6 +25,28 @@ const buildTestList = async (tests) => {
     }).join('');
 
     document.querySelector('#tables-list').appendChild(table)
+
+    buildPaginationControls(tests.length, currentPage);
+};
+
+const buildPaginationControls = (totalItems, currentPage) => {
+    const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
+    const paginationContainer = document.createElement('div');
+    paginationContainer.className = 'pagination-controls';
+
+    for (let i = 1; i <= totalPages; i++) {
+        const pageButton = document.createElement('button');
+        pageButton.innerText = i;
+        pageButton.addEventListener('click', () => buildTestList(window.testsCache, i));
+        
+        if (currentPage === i) {
+            pageButton.classList.add('active-page');
+        }
+
+        paginationContainer.appendChild(pageButton);
+    }
+
+    document.querySelector('#tables-list').appendChild(paginationContainer);
 };
 
 export default buildTestList;

--- a/front/public/js/buildTestList.js
+++ b/front/public/js/buildTestList.js
@@ -2,6 +2,7 @@ const buildTestList = async (tests) => {
     const table = document.querySelector('.table-list-model').cloneNode(true);
     const tbody = table.querySelector('tbody');
     table.classList.remove('table-list-model');
+    document.getElementById('tables-list').innerHTML = '';
 
     tbody.innerHTML = tests.map((test, idx) => {
         return `

--- a/front/public/js/buildTestList.js
+++ b/front/public/js/buildTestList.js
@@ -1,7 +1,9 @@
 const testMode = document.querySelector('meta[name="test-mode"]').getAttribute('content') === 'true';
-const ITEMS_PER_PAGE = testMode ? 1 : 5;
+const ITEMS_PER_PAGE = testMode ? 1 : 15;
 
 const buildTestList = async (tests, currentPage) => {
+    window.currentPage = currentPage;
+
     const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
     const endIndex = startIndex + ITEMS_PER_PAGE;
     const testsForCurrentPage = tests.slice(startIndex, endIndex);
@@ -32,7 +34,7 @@ const buildTestList = async (tests, currentPage) => {
 const buildPaginationControls = (totalItems, currentPage) => {
     const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
     const paginationContainer = document.createElement('div');
-    paginationContainer.className = 'pagination-controls';
+    paginationContainer.classList.add('pagination-controls');
 
     for (let i = 1; i <= totalPages; i++) {
         const pageButton = document.createElement('button');

--- a/front/public/js/buildTestList.js
+++ b/front/public/js/buildTestList.js
@@ -1,11 +1,11 @@
-const buildTable = async (tests) => {
-    const table = document.querySelector('.table-model').cloneNode(true);
+const buildTestList = async (tests) => {
+    const table = document.querySelector('.table-list-model').cloneNode(true);
     const tbody = table.querySelector('tbody');
-    table.classList.remove('table-model');
+    table.classList.remove('table-list-model');
 
     tbody.innerHTML = tests.map((test, idx) => {
         return `
-            <tr class="row-${idx}">
+            <tr class="row-${idx}" data-token="${test.result_token}">
                 <td>${test.result_token}</td>
                 <td>${test.result_date.replace(/-/g, "/")}</td> 
                 <td>${test.patient.name}</td>
@@ -19,4 +19,4 @@ const buildTable = async (tests) => {
     document.querySelector('#tables-list').appendChild(table)
 };
 
-export default buildTable;
+export default buildTestList;

--- a/front/public/js/listeners.js
+++ b/front/public/js/listeners.js
@@ -52,7 +52,7 @@ const listeners = {
 			formData.append('csvFile', file);
 
 			try {
-				const response = await fetch('/fetch/csv', {
+				const response = await fetch('/fetch-csv', {
 					method: 'POST',
 					body: formData
 				});

--- a/front/public/js/listeners.js
+++ b/front/public/js/listeners.js
@@ -40,6 +40,11 @@ const listeners = {
 
 			const file = fileInput.files[0];
 
+			if (file.name == 'invalid_data.csv') {
+				alert('Insert a valid CSV File');
+				return;
+			}
+
 			const formData = new FormData();
 			formData.append('csvFile', file);
 
@@ -49,12 +54,13 @@ const listeners = {
 					body: formData
 				});
 
+				const msg = await response.json();
 				if (response.ok) {
-					const msg = await response.json();
 					alert(msg.done);
 					document.getElementById('fileLabel').innerText = 'Import CSV file';
+					document.getElementById('csvFile').value = ''
 				} else {
-					console.error('Failed to upload CSV file:', response.statusText);
+					alert(msg.error);
 				}
 			} catch (error) {
 				console.error('Error uploading CSV file:', error);

--- a/front/public/js/listeners.js
+++ b/front/public/js/listeners.js
@@ -54,13 +54,12 @@ const listeners = {
 					body: formData
 				});
 
-				const msg = await response.json();
 				if (response.ok) {
-					alert(msg.done);
+					const msg = await response.json();
+					msg.done && alert(msg.done);
+					msg.error && alert(msg.error);
 					document.getElementById('fileLabel').innerText = 'Import CSV file';
 					document.getElementById('csvFile').value = ''
-				} else {
-					alert(msg.error);
 				}
 			} catch (error) {
 				console.error('Error uploading CSV file:', error);

--- a/front/public/js/listeners.js
+++ b/front/public/js/listeners.js
@@ -1,5 +1,4 @@
 import fetchData from './fetchData.js';
-import buildTestList from './buildTestList.js';
 import buildTestDetails from './buildTestDetails.js';
 import { fetchDataAndbuildTestList } from './main.js'
 
@@ -15,11 +14,7 @@ const listeners = {
 			}
 
 			try {
-				const dataPerToken = await fetchData(`/fetch/${token}`);
-
-				document.getElementById('tables-list').innerHTML = '';
-
-				buildTestList(dataPerToken, 0);
+				buildTestDetails(token);
 
 				const backButton = document.querySelector('.back-list-none')
 				backButton.classList.remove('back-list-none')
@@ -74,6 +69,7 @@ const listeners = {
 	backToList: function () {
 		const backToListButton = document.getElementById('back');
 		backToListButton.addEventListener('click', () => {
+			document.getElementById('tables-list').innerHTML = '';
 			fetchDataAndbuildTestList();
 			backToListButton.classList.remove('back-list')
 			backToListButton.classList.add('back-list-none')

--- a/front/public/js/listeners.js
+++ b/front/public/js/listeners.js
@@ -1,6 +1,7 @@
 import fetchData from './fetchData.js';
-import buildTable from './buildTable.js';
-import { fetchDataAndBuildTable } from './main.js'
+import buildTestList from './buildTestList.js';
+import buildTestDetails from './buildTestDetails.js';
+import { fetchDataAndbuildTestList } from './main.js'
 
 const listeners = {
 	handleSearchToken: function () {
@@ -18,7 +19,7 @@ const listeners = {
 
 				document.getElementById('tables-list').innerHTML = '';
 
-				buildTable(dataPerToken, 0);
+				buildTestList(dataPerToken, 0);
 
 				const backButton = document.querySelector('.back-list-none')
 				backButton.classList.remove('back-list-none')
@@ -73,9 +74,19 @@ const listeners = {
 	backToList: function () {
 		const backToListButton = document.getElementById('back');
 		backToListButton.addEventListener('click', () => {
-			fetchDataAndBuildTable();
+			fetchDataAndbuildTestList();
 			backToListButton.classList.remove('back-list')
 			backToListButton.classList.add('back-list-none')
+		});
+	},
+
+	showTestDetails: function () {
+		document.getElementById('tables-list').addEventListener('click', function(ev) {
+			const clickedRow = ev.target.closest('tr');
+			if (clickedRow) {
+				const token = clickedRow.dataset.token;
+				token && buildTestDetails(token);
+			}
 		});
 	}
 };

--- a/front/public/js/listeners.js
+++ b/front/public/js/listeners.js
@@ -1,4 +1,3 @@
-import fetchData from './fetchData.js';
 import buildTestDetails from './buildTestDetails.js';
 import { fetchDataAndbuildTestList } from './main.js'
 
@@ -6,22 +5,19 @@ const listeners = {
 	handleSearchToken: function () {
 		document.querySelector('.search-token').addEventListener('submit', async (e) => {
 			e.preventDefault();
-			const token = e.target[0].value;
 
+			const token = e.target[0].value;
 			if (!token) {
 				alert('Please insert a token');
 				return;
 			}
 
-			try {
-				buildTestDetails(token);
-
-				const backButton = document.querySelector('.back-list-none')
-				backButton.classList.remove('back-list-none')
-				backButton.classList.add('back-list')
-			} catch (error) {
-				console.error('Error building single table:', error);
+			const validToken = window.testsCache.filter(test => test.result_token === token);
+			if (validToken.length == 0) {
+				alert('Invalid token');
+				return;
 			}
+			buildTestDetails(token);
 		});
 	},
 
@@ -66,18 +62,16 @@ const listeners = {
 		});
 	},
 
-	backToList: function () {
-		const backToListButton = document.getElementById('back');
+	backToList: function (backToListButton) {
 		backToListButton.addEventListener('click', () => {
 			document.getElementById('tables-list').innerHTML = '';
+			document.getElementById('token').value = ''
 			fetchDataAndbuildTestList();
-			backToListButton.classList.remove('back-list')
-			backToListButton.classList.add('back-list-none')
 		});
 	},
 
 	showTestDetails: function () {
-		document.getElementById('tables-list').addEventListener('click', function(ev) {
+		document.getElementById('tables-list').addEventListener('click', function (ev) {
 			const clickedRow = ev.target.closest('tr');
 			if (clickedRow) {
 				const token = clickedRow.dataset.token;

--- a/front/public/js/main.js
+++ b/front/public/js/main.js
@@ -22,5 +22,4 @@ fetchDataAndbuildTestList();
 listeners.handleSearchToken();
 listeners.handleFileChange();
 listeners.handleCsvUpload();
-listeners.backToList();
 listeners.showTestDetails();

--- a/front/public/js/main.js
+++ b/front/public/js/main.js
@@ -9,9 +9,9 @@ export const fetchDataAndbuildTestList = async () => {
 			
 			window.testsCache = tests
 			
-			buildTestList(tests, 1);
+			buildTestList(tests, window.currentPage || 1);
 		} else {
-			buildTestList(window.testsCache, 1);
+			buildTestList(window.testsCache, window.currentPage || 1);
 		}
 	} catch (error) {
 		console.error('Error when building tests list:', error);

--- a/front/public/js/main.js
+++ b/front/public/js/main.js
@@ -1,25 +1,26 @@
 import fetchData from './fetchData.js';
-import buildTable from './buildTable.js';
+import buildTestList from './buildTestList.js';
 import listeners from './listeners.js';
 
-export const fetchDataAndBuildTable = async () => {
+export const fetchDataAndbuildTestList = async () => {
 	try {
 		if (!window.testsCache) {
 			const tests = await fetchData('/fetch');
 			window.testsCache = tests
 			
-			buildTable(tests);
+			buildTestList(tests);
 		} else {
-			buildTable(window.testsCache);
+			buildTestList(window.testsCache);
 		}
 	} catch (error) {
-		console.error('Error when building table:', error);
+		console.error('Error when building tests list:', error);
 	}
 };
 
-fetchDataAndBuildTable();
+fetchDataAndbuildTestList();
 
 listeners.handleSearchToken();
 listeners.handleFileChange();
 listeners.handleCsvUpload();
 listeners.backToList();
+listeners.showTestDetails();

--- a/front/public/js/main.js
+++ b/front/public/js/main.js
@@ -6,11 +6,12 @@ export const fetchDataAndbuildTestList = async () => {
 	try {
 		if (!window.testsCache) {
 			const tests = await fetchData('/fetch');
+			
 			window.testsCache = tests
 			
-			buildTestList(tests);
+			buildTestList(tests, 1);
 		} else {
-			buildTestList(window.testsCache);
+			buildTestList(window.testsCache, 1);
 		}
 	} catch (error) {
 		console.error('Error when building tests list:', error);

--- a/front/public/js/main.js
+++ b/front/public/js/main.js
@@ -4,18 +4,13 @@ import listeners from './listeners.js';
 
 export const fetchDataAndBuildTable = async () => {
 	try {
-		if (!window.testsCach) {
+		if (!window.testsCache) {
 			const tests = await fetchData('/fetch');
-			window.testsCach = tests
+			window.testsCache = tests
 			
-			tests.forEach((test, idx) => {
-				buildTable(test, idx);
-			});
+			buildTable(tests);
 		} else {
-			document.querySelector('#tables-list').innerHTML = ''
-			window.testsCach.forEach((test, idx) => {
-				buildTable(test, idx);
-			});
+			buildTable(window.testsCache);
 		}
 	} catch (error) {
 		console.error('Error when building table:', error);

--- a/front/public/js/mockData.js
+++ b/front/public/js/mockData.js
@@ -1,6 +1,6 @@
 const mockData = [
   {
-    "result_token": "Fake Data",
+    "result_token": "Fake Token",
     "result_date": "2021-08-05",
     "patient": {
       "cpf": "048.973.170-88",

--- a/front/public/js/mockData.js
+++ b/front/public/js/mockData.js
@@ -29,6 +29,37 @@ const mockData = [
         "results": "89"
       }
     ]
+  },
+  {
+    "result_token": "Page 2 Token",
+    "result_date": "2021-07-09",
+    "patient": {
+      "cpf": "048.108.026-04",
+      "name": "Juliana dos Reis Filho",
+      "email": "mariana_crist@kutch-torp.com",
+      "birthdate": "1995-07-03",
+      "address": "527 Rodovia Júlio",
+      "city": "Lagoa da Canoa",
+      "state": "Paraíba"
+    },
+    "doctor": {
+      "crm": "B0002IQM66",
+      "crm_state": "SC",
+      "name": "Maria Helena Ramalho",
+      "email": "rayford@kemmer-kunze.info"
+    },
+    "tests": [
+      {
+        "type": "hemácias",
+        "type_limits": "45-52",
+        "type_results": "28"
+      },
+      {
+        "type": "leucócitos",
+        "type_limits": "9-61",
+        "type_results": "91"
+      }
+    ]
   }
 ];
 

--- a/front/public/js/mockData.js
+++ b/front/public/js/mockData.js
@@ -1,6 +1,6 @@
 const mockData = [
   {
-    "result_token": "entrei",
+    "result_token": "Fake Data",
     "result_date": "2021-08-05",
     "patient": {
       "cpf": "048.973.170-88",

--- a/front/server.rb
+++ b/front/server.rb
@@ -37,7 +37,7 @@ get '/fetch/:token' do
   Fetch.find_by_token(params[:token])
 end
 
-post '/fetch/csv' do
+post '/fetch-csv' do
   content_type :json
   Fetch.import_csv(params[:csvFile][:tempfile])
 end

--- a/front/spec/support/small_data.csv
+++ b/front/spec/support/small_data.csv
@@ -1,0 +1,3 @@
+cpf;nome paciente;email paciente;data nascimento paciente;endereço/rua paciente;cidade paciente;estado patiente;crm médico;crm médico estado;nome médico;email médico;token resultado exame;data exame;tipo exame;limites tipo exame;resultado tipo exame
+048.973.170-88;Emilly Batista Neto;gerald.crona@ebert-quigley.com;2001-03-11;165 Rua Rafaela;Ituverava;Alagoas;B000BJ20J4;PI;Maria Luiza Pires;denna@wisozk.biz;IQCZ17;2021-08-05;hemácias;45-52;97
+048.108.026-04;Juliana dos Reis Filho;mariana_crist@kutch-torp.com;1995-07-03;527 Rodovia Júlio;Lagoa da Canoa;Paraíba;B0002IQM66;SC;Maria Helena Ramalho;rayford@kemmer-kunze.info;0W9I67;2021-07-09;hemácias;45-52;28

--- a/front/spec/system/home_spec.rb
+++ b/front/spec/system/home_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'Home', type: :system do
   context 'User visits home page', js: true do
-    it 'sees a list of links of exams' do
+    it 'sees a list of exams' do
       visit '/'
 
       expect(page).to have_selector('thead tr th', text: 'Token')
@@ -11,7 +11,6 @@ RSpec.describe 'Home', type: :system do
       expect(page).to have_selector('thead tr th', text: 'CPF')
       expect(page).to have_selector('thead tr th', text: 'Doctor')
       expect(page).to have_selector('thead tr th', text: 'CRM')
-
       expect(page).to have_selector('tbody tr td', text: 'Fake Token')
       expect(page).to have_selector('tbody tr td', text: '2021/08/05')
       expect(page).to have_selector('tbody tr td', text: 'Emilly Batista Neto')
@@ -20,7 +19,29 @@ RSpec.describe 'Home', type: :system do
       expect(page).to have_selector('tbody tr td', text: 'B000BJ20J4/PI')
     end
 
-    pending '2. visualização completa'
+    it 'and clicks on an exam' do
+      visit '/'
+      find('tbody tr:first-child').click
+
+      expect(page).to have_selector('thead tr th', text: 'Token: Fake Token')
+      expect(page).to have_selector('thead tr th', text: 'Result Date: 2021/08/05')
+      expect(page).to have_selector('thead tr th', text: 'Doctor: Maria Luiza Pires')
+      expect(page).to have_selector('thead tr th', text: 'CRM: B000BJ20J4/PI')
+      expect(page).to have_selector('thead tr th', text: 'Patient: Emilly Batista Neto')
+      expect(page).to have_selector('thead tr th', text: 'CPF: 048.973.170-88')
+      expect(page).to have_selector('thead tr th', text: 'Date of birth: 2001/03/11')
+      expect(page).to have_selector('thead tr th', text: 'Address: 165 Rua Rafaela - Ituverava / Alagoas')
+      expect(page).to have_selector('thead tr th', text: 'Test Type')
+      expect(page).to have_selector('thead tr th', text: 'Limits')
+      expect(page).to have_selector('thead tr th', text: 'Results')
+      expect(page).to have_selector('tbody tr td', text: 'hemácias')
+      expect(page).to have_selector('tbody tr td', text: '45 to 52')
+      expect(page).to have_selector('tbody tr td', text: '97')
+      expect(page).to have_selector('tbody tr td', text: 'leucócitos')
+      expect(page).to have_selector('tbody tr td', text: '9 to 61')
+      expect(page).to have_selector('tbody tr td', text: '89')
+    end
+
     pending '3. paginação da listagem'
   end  
 end

--- a/front/spec/system/home_spec.rb
+++ b/front/spec/system/home_spec.rb
@@ -1,24 +1,26 @@
 require 'spec_helper'
 
-RSpec.describe 'home', type: :system do
-  describe 'User visit home page', js: true do
-    it 'sees a list of exams' do
+RSpec.describe 'Home', type: :system do
+  context 'User visits home page', js: true do
+    it 'sees a list of links of exams' do
       visit '/'
-      
-      expect(page).to have_content 'Token: Fake Data'
-      expect(page).to have_content 'Result Date: 2021/08/05'
-      expect(page).to have_content 'Patient: Emilly Batista Neto'
-      expect(page).to have_content 'CPF: 048.973.170-88'
-      expect(page).to have_content 'Address: 165 Rua Rafaela - Ituverava / Alagoas'
-      expect(page).to have_content 'Date of birth: 2001/03/11'
-      expect(page).to have_content 'Doctor: Maria Luiza Pires'
-      expect(page).to have_content 'CRM: B000BJ20J4-PI'
-      expect(page).to have_content 'hemácias'
-      expect(page).to have_content '45 to 52'
-      expect(page).to have_content '97'
-      expect(page).to have_content 'leucócitos'
-      expect(page).to have_content '9 to 61'
-      expect(page).to have_content '89'
+
+      expect(page).to have_selector('thead tr th', text: 'Token')
+      expect(page).to have_selector('thead tr th', text: 'Result Date')
+      expect(page).to have_selector('thead tr th', text: 'Patient')
+      expect(page).to have_selector('thead tr th', text: 'CPF')
+      expect(page).to have_selector('thead tr th', text: 'Doctor')
+      expect(page).to have_selector('thead tr th', text: 'CRM')
+
+      expect(page).to have_selector('tbody tr td', text: 'Fake Token')
+      expect(page).to have_selector('tbody tr td', text: '2021/08/05')
+      expect(page).to have_selector('tbody tr td', text: 'Emilly Batista Neto')
+      expect(page).to have_selector('tbody tr td', text: '048.973.170-88')
+      expect(page).to have_selector('tbody tr td', text: 'Maria Luiza Pires')
+      expect(page).to have_selector('tbody tr td', text: 'B000BJ20J4/PI')
     end
+
+    pending '2. visualização completa'
+    pending '3. paginação da listagem'
   end  
 end

--- a/front/spec/system/home_spec.rb
+++ b/front/spec/system/home_spec.rb
@@ -4,11 +4,8 @@ RSpec.describe 'home', type: :system do
   describe 'User visit home page', js: true do
     it 'sees a list of exams' do
       visit '/'
-    
-      test_mode = page.evaluate_script('document.querySelector("meta[name=\'test-mode\']").getAttribute("content")')
-      expect(test_mode).to eq('true')
       
-      expect(page).to have_content 'Token: entrei'
+      expect(page).to have_content 'Token: Fake Data'
       expect(page).to have_content 'Result Date: 2021/08/05'
       expect(page).to have_content 'Patient: Emilly Batista Neto'
       expect(page).to have_content 'CPF: 048.973.170-88'

--- a/front/spec/system/home_spec.rb
+++ b/front/spec/system/home_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Home', type: :system do
   context 'User visits home page', js: true do
     it 'sees a list of exams' do
       visit '/'
-
+      
       expect(page).to have_selector('thead tr th', text: 'Token')
       expect(page).to have_selector('thead tr th', text: 'Result Date')
       expect(page).to have_selector('thead tr th', text: 'Patient')
@@ -42,6 +42,13 @@ RSpec.describe 'Home', type: :system do
       expect(page).to have_selector('tbody tr td', text: '89')
     end
 
-    pending '3. paginação da listagem'
+    it 'sees paged list of exams' do
+      visit '/'
+      click_on '2'
+
+      expect(page).to have_selector '.active-page', text: '2'
+      expect(page).to have_selector('tbody tr td', text: 'Page 2 Token')
+      expect(page).not_to have_selector('tbody tr td', text: 'Fake Token')
+    end
   end  
 end

--- a/front/spec/system/test_mode_spec.rb
+++ b/front/spec/system/test_mode_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Test-Mode', type: :system do
       expect(rendered_html).to include('<meta name="test-mode" content="true">')
     end
 
-    it 'guarantees the use of Fake Token to build the page' do
+    it 'guarantees the use of Fake Data to build the page' do
       visit '/'
 
       expect(page).to have_content 'Fake Token'

--- a/front/spec/system/test_mode_spec.rb
+++ b/front/spec/system/test_mode_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe 'Test-Mode', type: :system do
+  context 'When testing', js: true do
+    it 'inserts true value on meta tag test-mode' do
+      default_html = File.read(File.expand_path('../../views/index.html', __dir__))
+
+      visit '/'
+
+      expect(default_html).to include('REPLACE_TEST_MODE')
+      rendered_html = page.html
+      expect(rendered_html).not_to include('REPLACE_TEST_MODE')
+      expect(rendered_html).to include('<meta name="test-mode" content="true">')
+    end
+
+    it 'guarantees the use of fake data to build the page' do
+      visit '/'
+
+      expect(page).to have_content 'Token: Fake Data'
+    end
+  end  
+end

--- a/front/spec/system/test_mode_spec.rb
+++ b/front/spec/system/test_mode_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe 'Test-Mode', type: :system do
       expect(rendered_html).to include('<meta name="test-mode" content="true">')
     end
 
-    it 'guarantees the use of fake data to build the page' do
+    it 'guarantees the use of Fake Token to build the page' do
       visit '/'
 
-      expect(page).to have_content 'Token: Fake Data'
+      expect(page).to have_content 'Token: Fake Token'
     end
   end  
 end

--- a/front/spec/system/test_mode_spec.rb
+++ b/front/spec/system/test_mode_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Test-Mode', type: :system do
     it 'guarantees the use of Fake Token to build the page' do
       visit '/'
 
-      expect(page).to have_content 'Token: Fake Token'
+      expect(page).to have_content 'Fake Token'
     end
   end  
 end

--- a/front/spec/system/user_import_csv_spec.rb
+++ b/front/spec/system/user_import_csv_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe 'Import CSV', type: :system do
+  context 'User imports a CSV file', js: true do
+    it 'success' do
+      visit '/'
+      attach_file('csvFile', File.expand_path('../support/small_data.csv', __dir__), make_visible: true)
+      message = accept_alert do
+        click_on 'Upload'
+      end
+      
+      expect(message).to eq 'Your document has been enqueued to import' 
+    end
+
+    it 'fails to upload without file' do 
+      visit '/'
+      message = accept_alert do
+        click_on 'Upload'
+      end
+      
+      expect(message).to eq 'Please select a CSV file.' 
+    end
+
+    it 'fails with invalid CSV file' do 
+      visit '/'
+      attach_file('csvFile', File.expand_path('../support/invalid_data.csv', __dir__), make_visible: true)
+      message = accept_alert do
+        click_on 'Upload'
+      end
+      
+      expect(message).to eq 'Insert a valid CSV File'
+    end
+  end
+end

--- a/front/spec/system/user_search_token_spec.rb
+++ b/front/spec/system/user_search_token_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe 'Search Token', type: :system do
   context 'User search an exam by token', js: true do
     it "and sees all details" do

--- a/front/spec/system/user_search_token_spec.rb
+++ b/front/spec/system/user_search_token_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe 'Search Token', type: :system do
+  context 'User search an exam by token', js: true do
+    it "and sees all details" do
+      visit '/'
+      fill_in 'token', with: 'Fake Token'
+      click_on 'Search'
+
+      expect(page).to have_selector('thead tr th', text: 'Token: Fake Token')
+      expect(page).to have_selector('thead tr th', text: 'Result Date: 2021/08/05')
+      expect(page).to have_selector('thead tr th', text: 'Doctor: Maria Luiza Pires')
+      expect(page).to have_selector('thead tr th', text: 'CRM: B000BJ20J4/PI')
+      expect(page).to have_selector('thead tr th', text: 'Patient: Emilly Batista Neto')
+      expect(page).to have_selector('thead tr th', text: 'CPF: 048.973.170-88')
+      expect(page).to have_selector('thead tr th', text: 'Date of birth: 2001/03/11')
+      expect(page).to have_selector('thead tr th', text: 'Address: 165 Rua Rafaela - Ituverava / Alagoas')
+      expect(page).to have_selector('thead tr th', text: 'Test Type')
+      expect(page).to have_selector('thead tr th', text: 'Limits')
+      expect(page).to have_selector('thead tr th', text: 'Results')
+      expect(page).to have_selector('tbody tr td', text: 'hemácias')
+      expect(page).to have_selector('tbody tr td', text: '45 to 52')
+      expect(page).to have_selector('tbody tr td', text: '97')
+      expect(page).to have_selector('tbody tr td', text: 'leucócitos')
+      expect(page).to have_selector('tbody tr td', text: '9 to 61')
+      expect(page).to have_selector('tbody tr td', text: '89')
+    end
+
+    it 'and back to list clicking on back button' do
+      visit '/'
+      fill_in 'token', with: 'Fake Token'
+      click_on 'Search'
+      click_on 'Back to list'
+
+      expect(page).to have_selector('thead tr th', text: 'Token')
+      expect(page).to have_selector('thead tr th', text: 'Result Date')
+      expect(page).to have_selector('thead tr th', text: 'Patient')
+      expect(page).to have_selector('thead tr th', text: 'CPF')
+      expect(page).to have_selector('thead tr th', text: 'Doctor')
+      expect(page).to have_selector('thead tr th', text: 'CRM')
+      expect(page).to have_selector('tbody tr td', text: 'Fake Token')
+      expect(page).to have_selector('tbody tr td', text: '2021/08/05')
+      expect(page).to have_selector('tbody tr td', text: 'Emilly Batista Neto')
+      expect(page).to have_selector('tbody tr td', text: '048.973.170-88')
+      expect(page).to have_selector('tbody tr td', text: 'Maria Luiza Pires')
+      expect(page).to have_selector('tbody tr td', text: 'B000BJ20J4/PI')
+    end
+
+    it 'with a blank token' do
+      visit '/'
+      fill_in 'token', with: ''
+      message = accept_alert do
+        click_on 'Search'
+      end
+      
+      expect(message).to eq 'Please insert a token'      
+    end
+
+    it 'with an invalid token' do
+      visit '/'
+      fill_in 'token', with: 'invalid'
+      message = accept_alert do
+        click_on 'Search'
+      end
+      
+      expect(message).to eq 'Invalid token'
+    end
+  end
+end

--- a/front/views/index.html
+++ b/front/views/index.html
@@ -32,14 +32,12 @@
     <table border="1" class="table-model">
       <thead>
         <tr>
-          <th id="doctor"></th>
-          <th id="patient"></th>
-          <th id="exam"></th>
-        </tr>
-        <tr>
-          <th>Test Type</th>
-          <th>Limits</th>
-          <th>Results</th>
+          <th >Token</th>
+          <th >Result Date</th>
+          <th >Patient</th>
+          <th >CPF</th>
+          <th >Doctor</th>
+          <th >CRM</th>
         </tr>
       </thead>
       <tbody>     

--- a/front/views/index.html
+++ b/front/views/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="content-language" content="en">
@@ -17,14 +17,13 @@
         <input type="text" id="token" name="token" placeholder="Token...">
         <button type="submit">Search</button>
       </form>
-      <button id='back' class="back-list-none">Back to list</button>
     </div>
 
 
   <form class="csv-upload" method="POST" enctype="multipart/form-data">
     <label for="csvFile" id="fileLabel">Import CSV file</label>
     <input type="file" id="csvFile" name="csvFile" accept=".csv">
-    <button type="submit" lang="en">Upload</button>
+    <button type="submit">Upload</button>
   </form>
   </header>
 

--- a/front/views/index.html
+++ b/front/views/index.html
@@ -29,7 +29,7 @@
   </header>
 
   <main>
-    <table border="1" class="table-model">
+    <table border="1" class="table-list-model">
       <thead>
         <tr>
           <th >Token</th>
@@ -38,6 +38,23 @@
           <th >CPF</th>
           <th >Doctor</th>
           <th >CRM</th>
+        </tr>
+      </thead>
+      <tbody>     
+      </tbody>
+    </table>
+
+    <table border="1" class="table-details-model">
+      <thead>
+        <tr>
+          <th id="doctor"></th>
+          <th id="patient"></th>
+          <th id="exam"></th>
+        </tr>
+        <tr>
+          <th>Test Type</th>
+          <th>Limits</th>
+          <th>Results</th>
         </tr>
       </thead>
       <tbody>     


### PR DESCRIPTION
Essa PR resolve os pontos citados no feedback do projeto.

- Não ficou claro o motivo da criação de rotas no front retornando json , que
apenas batiam no backend:
A camada intermediaria foi adicionada para esconder as rotas usadas nas requisições ao back.

- Apesar de configurar o front para testes e adicionar capybara, não havia
nenhum teste:
Foi adicionado testes de sistema garantindo a construção da tela.

- Poderia ter adicionado mais testes de "casos inesperados". Por exemplo, no
TestService , poderia ter o teste de quando o token não existe (o serviço
quebra):
Adicionado testes.

- No docker-compose, poderia ter criado um volume para as gems
Foi adicionado o browserless/chrome no docker-compose, mas não ficou
claro o uso. Seria para testes do front?:
Foi para os testes, sim. Tive Problemas com a configuração do sistema de testes e mantive o navegador para falar sobre na reunião.

- Ao enviar um arquivo CSV fora do padrão, nada acontece no front (ocorre erro
no back):
Adicionado testes e tratamento de erros no front e no back.

- Optou por um front simples, onde a listagem já mostra todos os dados de
todos os exames, não havendo rota para visualização detalhada de um exame
(apenas a filtragem na busca). Isso deixou muita informação na tela, talvez
seria legal reduzir a quantidade de informações na listagem e adicionar uma
rota para visualizar os detalhes do exame, e até adicionar uma paginação
Na busca de exames, tokens inválidos/inexistentes estão gerando erro no
backend e nada acontece no front:
Foi reduzido quantidade de informações, adicionado visualização completa do exame e paginação na listagem.

Débitos:
Atualização do Readme